### PR TITLE
Facebook events for locations only return 25.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bundle
 .env
-tmp/
 coverage/
+tmp/
+vendor/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 Service API for Pearl, Downtown Grand Rapids Inc.'s website. Mantle provides a standardized interface for Pearl to access data from various endpoints providing event, business, and location information.
 
-# Getting Started
+## Getting Started
+
+Dependencies: `postgresql`, `ruby 2.1.4`
 
 Within the project's directory, start with this:
 ```ruby
@@ -16,11 +18,23 @@ cp .env.example .env
 ```
 Update `.env` with appropriate service tokens. Be sure to set `MANTLE_USER` and `MANTLE_PASS`. You'll need those credentials to access the API.
 
-Type this to run:
+[Setup a local database](https://devcenter.heroku.com/articles/heroku-postgresql#local-setup). Heroku recommends running the same database locally as in production.
+
+```
+heroku config
+```
+Update `.env` with the appropriate database url.
+
+To run the Procfile-based app locally:
 ```ruby
 gem install foreman
 foreman start
 ```
+Alternatively, with [heroku local](https://devcenter.heroku.com/articles/getting-started-with-ruby#run-the-app-locally): `heroku local`
+
+### Tests
+
+- rspec `bundle exec rspec`
 
 # API
 

--- a/lib/facebook_page.rb
+++ b/lib/facebook_page.rb
@@ -40,7 +40,7 @@ class FacebookPage
   end
 
   def events
-    @events ||= @graph.get_connections(@id, "events")
+    @events ||= @graph.get_connections(@id, "events", { "limit" => "50", "since" => "now"})
 
     array = @events.map do |e|
       {


### PR DESCRIPTION
Facebook's Graph API defaults to 25 edge nodes. Rather than try and implement pagination, or batch requests, I've elected to update the limit to 50, with a since to parameter to the time of API call.

This should give us a reasonable buffer for now and near events with a nightly sync to pearl.
